### PR TITLE
don't prepend the bucket name to the file's path

### DIFF
--- a/src/main/java/org/springframework/aws/maven/PrivateS3Wagon.java
+++ b/src/main/java/org/springframework/aws/maven/PrivateS3Wagon.java
@@ -88,7 +88,7 @@ public class PrivateS3Wagon extends SimpleStorageServiceWagon {
     @Override
     protected void putResource(File source, String destination, TransferProgress progress) throws S3ServiceException, IOException {
         buildDestinationPath(getDestinationPath(destination));
-        S3Object object = new S3Object(this.bucket + destination);
+        S3Object object = new S3Object(this.basedir + destination);
         object.setAcl(AccessControlList.REST_CANNED_PRIVATE);
         object.setDataInputFile(source);
         object.setContentLength(source.length());


### PR DESCRIPTION
For a repo url like `s3p://bucket/snapshots`, existing code results in file paths like `bucketcom/org/foo/2.5.0-SNAPSHOT/foo-2.5.0-20120218.001538-1.pom` instead of `snapshots/com/org/foo/2.5.0-SNAPSHOT/foo-2.5.0-20120218.001538-1.pom`.
