### PR TITLE
fix instructions for maven settings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,9 @@ your project, so you should take them from the environment using
             <!-- you can actually put the key and secret in here, I like to get them from the env -->
             <id>someId</id>
             <username>${env.AWS_ACCESS_KEY}</username>
-            <password>${env.AWS_SECRET_KEY}</password>
+            <passphrase>${env.AWS_SECRET_KEY}</passphrase>
         </server>
-    <server>
-  </servers>
+    </servers>
 </settings>
 
 ```


### PR DESCRIPTION
there was an unclosed <server> tag, and the password tag should be passphrase
