### PR TITLE
Exclude aws-sdk from spring aws-maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,12 +51,32 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.wagon</groupId>
             <artifactId>wagon-provider-api</artifactId>
             <version>2.4</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.5.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.5.5</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Prevents a dependency conflict on Jackson

This was briefly discussed in #30 where the aws-sdk had a dependency conflict. (We ran into the same issue as @dball when using 1.3.0-SNAPSHOT and this exclusion helped in the meantime before possibly using the other fork of aws-maven). 