### PR TITLE
Exclude old version of aws-java-sdk from aws-maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
             <groupId>org.springframework.build</groupId>
             <artifactId>aws-maven</artifactId>
             <version>4.8.0.RELEASE</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.amazonaws</groupId>
+                    <artifactId>aws-java-sdk</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
I was having trouble with the suggestions in https://github.com/s3-wagon-private/s3-wagon-private/pull/36 and I noticed (atleast for myself) that the dependencies were resolving to an old version of the aws sdk which did not have support for `.aws/credentials`.

Here is what `mvn dependency:tree` looks like before and after this change. I have annotated the line that looks funny.
### Before Change

```
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building s3-wagon-private 1.3.0-alpha1
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ s3-wagon-private ---
[INFO] s3-wagon-private:s3-wagon-private:jar:1.3.0-alpha1
[INFO] +- org.springframework.build:aws-maven:jar:4.8.0.RELEASE:compile
[INFO] |  +- ch.qos.logback:logback-classic:jar:1.0.12:compile
[INFO] |  |  \- ch.qos.logback:logback-core:jar:1.0.12:compile
[INFO] |  +- com.amazonaws:aws-java-sdk:jar:1.4.3:compile              <--- boo :(
[INFO] |  |  +- org.apache.httpcomponents:httpclient:jar:4.1:compile
[INFO] |  |  |  \- org.apache.httpcomponents:httpcore:jar:4.1:compile
[INFO] |  |  +- commons-codec:commons-codec:jar:1.3:compile
[INFO] |  |  +- org.codehaus.jackson:jackson-core-asl:jar:1.8.9:compile
[INFO] |  |  \- org.codehaus.jackson:jackson-mapper-asl:jar:1.8.9:compile
[INFO] |  +- org.slf4j:jcl-over-slf4j:jar:1.7.5:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.5:compile
[INFO] +- com.amazonaws:aws-java-sdk-s3:jar:1.11.28:compile
[INFO] |  +- com.amazonaws:aws-java-sdk-kms:jar:1.11.28:compile
[INFO] |  +- com.amazonaws:aws-java-sdk-core:jar:1.11.28:compile
[INFO] |  |  +- commons-logging:commons-logging:jar:1.1.3:compile
[INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.6.6:compile
[INFO] |  |  \- joda-time:joda-time:jar:2.8.1:compile
[INFO] |  \- com.amazonaws:jmespath-java:jar:1.0:compile
[INFO] +- org.apache.maven.wagon:wagon-provider-api:jar:2.4:provided
[INFO] |  \- org.codehaus.plexus:plexus-utils:jar:3.0.8:provided
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.5.5:compile
[INFO] \- com.fasterxml.jackson.core:jackson-databind:jar:2.5.5:compile
[INFO]    \- com.fasterxml.jackson.core:jackson-annotations:jar:2.5.0:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.854 s
[INFO] Finished at: 2016-10-26T19:16:58-07:00
[INFO] Final Memory: 14M/309M
[INFO] ------------------------------------------------------------------------
```
### After Change

```
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building s3-wagon-private 1.3.0-alpha1
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ s3-wagon-private ---
[INFO] s3-wagon-private:s3-wagon-private:jar:1.3.0-alpha1
[INFO] +- org.springframework.build:aws-maven:jar:4.8.0.RELEASE:compile
[INFO] |  +- ch.qos.logback:logback-classic:jar:1.0.12:compile
[INFO] |  |  \- ch.qos.logback:logback-core:jar:1.0.12:compile
[INFO] |  +- org.slf4j:jcl-over-slf4j:jar:1.7.5:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.5:compile
[INFO] +- com.amazonaws:aws-java-sdk-s3:jar:1.11.28:compile                 <--- yay :)
[INFO] |  +- com.amazonaws:aws-java-sdk-kms:jar:1.11.28:compile
[INFO] |  +- com.amazonaws:aws-java-sdk-core:jar:1.11.28:compile
[INFO] |  |  +- commons-logging:commons-logging:jar:1.1.3:compile
[INFO] |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.2:compile
[INFO] |  |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.4:compile
[INFO] |  |  |  \- commons-codec:commons-codec:jar:1.9:compile
[INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.6.6:compile
[INFO] |  |  \- joda-time:joda-time:jar:2.8.1:compile
[INFO] |  \- com.amazonaws:jmespath-java:jar:1.0:compile
[INFO] +- org.apache.maven.wagon:wagon-provider-api:jar:2.4:provided
[INFO] |  \- org.codehaus.plexus:plexus-utils:jar:3.0.8:provided
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.5.5:compile
[INFO] \- com.fasterxml.jackson.core:jackson-databind:jar:2.5.5:compile
[INFO]    \- com.fasterxml.jackson.core:jackson-annotations:jar:2.5.0:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.864 s
[INFO] Finished at: 2016-10-26T19:16:34-07:00
[INFO] Final Memory: 13M/245M
[INFO] ------------------------------------------------------------------------
```
