### PR TITLE
Support cn-north-1 and us-gov-west-1 buckets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ target
 /.lein-failures
 /checkouts
 /.lein-deps-sum
+.classpath
+.settings
+.project


### PR DESCRIPTION
For cn-north-1 and us-gov-west-1 it's not possible to check the bucket location using a default endpoint. The AWS credentials for those regions are not valid for the default S3 endpoint since the users and keys exist in an entirely different AWS partition.

With this change s3-wagon-private will attempt to detect the region using the DefaultAwsRegionProviderChain (`AWS_REGION` env var, then current AWS profile, then instance metadata). If the region is detected and belongs to a different aws partition than the standard "aws", then it will let the AmazonS3 client decide the S3 endpoint. If the region is detected as belonging to the standard AWS partition "aws", then the endpoint is detected uses the bucket location, as it has in the past.

Note, as part of this change regions not yet present in the aws-maven project are also supported.