### PR TITLE
Remove unnecessary calls to create S3 Bucket prefixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased (1.3.1?)]
 
+Removes unnecessary creation of bucket prefixes in S3. This gives users the ability to narrow the scope AWS Permissions for artifact uploads. 
 
 ## [1.3.0] - 2017-01-31
 

--- a/src/main/java/org/springframework/build/aws/maven/PrivateS3Wagon.java
+++ b/src/main/java/org/springframework/build/aws/maven/PrivateS3Wagon.java
@@ -216,8 +216,6 @@ public final class PrivateS3Wagon extends AbstractWagon {
         ResourceDoesNotExistException {
         String key = getKey(destination);
 
-        mkdirs(key, 0);
-
         InputStream in = null;
         try {
             ObjectMetadata objectMetadata = new ObjectMetadata();
@@ -264,32 +262,6 @@ public final class PrivateS3Wagon extends AbstractWagon {
             return matcher.group(1);
         }
         return key;
-    }
-
-    private void mkdirs(String path, int index) throws TransferFailedException {
-        int directoryIndex = path.indexOf('/', index) + 1;
-
-        if (directoryIndex != 0) {
-            String directory = path.substring(0, directoryIndex);
-            PutObjectRequest putObjectRequest = createDirectoryPutObjectRequest(directory);
-
-            try {
-                this.amazonS3.putObject(putObjectRequest);
-            } catch (AmazonServiceException e) {
-                throw new TransferFailedException(String.format("Cannot write directory '%s'", directory), e);
-            }
-
-            mkdirs(path, directoryIndex);
-        }
-    }
-
-    private PutObjectRequest createDirectoryPutObjectRequest(String key) {
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
-
-        ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setContentLength(0);
-
-        return new PutObjectRequest(this.bucketName, key, inputStream, objectMetadata);
     }
 
 }

--- a/test/sample-project/.gitignore
+++ b/test/sample-project/.gitignore
@@ -1,0 +1,2 @@
+maven-metadata.xml
+pom.xml

--- a/test/sample-project/project.clj
+++ b/test/sample-project/project.clj
@@ -1,0 +1,6 @@
+(defproject s3-wagon-private/test-project "0.0.1-SNAPSHOT"
+  :license "no-license"
+  :url "https://github.com/s3-wagon-private/s3-wagon-private"
+  :description "This is a test repository"
+  :plugins [[s3-wagon-private "1.3.1-SNAPSHOT"]]
+  :repositories [["testing" {:url "s3p://wagon/snapshots" :no-auth true}]])

--- a/test/sample-project/src/s3_wagon_private/test_project/core.clj
+++ b/test/sample-project/src/s3_wagon_private/test_project/core.clj
@@ -1,0 +1,4 @@
+(ns s3-wagon-private.test-project.core)
+
+(defn -main [& args]
+  (println "I don't do anything"))


### PR DESCRIPTION
Fixes #42 . Allows users to lock down IAM Credentials for artifact uploads.

<details>
<summary>Example IAM Policy</summary>

``` json
  {
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:List*",
                "s3:Get*"
            ],
            "Resource": [
                "arn:aws:s3:::wagon*"
            ]
        },
        {
            "Effect": "Allow",
            "Action": [
                "s3:Put*"
            ],
            "Resource": [
                "arn:aws:s3:::wagon/snapshots/s3-wagon-private/test-project/*"
            ]
        }
    ]
}
```

</details>

### Testing Notes:

1. Create an empty bucket
2. Call `lein deploy` with an empty repository
3. Call `lein deploy` with a non-empty repository
4. Assert artifacts exist in s3 bucket

<details>
<summary>Test Output</summary>

```
❯ AWS_PROFILE=noob aws s3 ls s3://wagon/snapshots

~/projects/s3-wagon-private/test/sample-project x-remove-mkdirs*
❯ AWS_PROFILE=noob lein deploy testing
Created /Users/rayh/projects/s3-wagon-private/test/sample-project/target/test-project-0.0.1-SNAPSHOT.jar
Wrote /Users/rayh/projects/s3-wagon-private/test/sample-project/pom.xml
Retrieving s3-wagon-private/test-project/0.0.1-SNAPSHOT/maven-metadata.xml
    from s3p://wagon/snapshots/
Could not find metadata s3-wagon-private:test-project:0.0.1-SNAPSHOT/maven-metadata.xml in testing (s3p://wagon/snapshots)
Sending s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045459-1.jar
    to s3p://wagon/snapshots/
Sending s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045459-1.pom
    to s3p://wagon/snapshots/
Retrieving s3-wagon-private/test-project/maven-metadata.xml
    from s3p://wagon/snapshots/
Could not find metadata s3-wagon-private:test-project/maven-metadata.xml in testing (s3p://wagon/snapshots)
Sending s3-wagon-private/test-project/0.0.1-SNAPSHOT/maven-metadata.xml
    to s3p://wagon/snapshots/
Sending s3-wagon-private/test-project/maven-metadata.xml
    to s3p://wagon/snapshots/

~/projects/s3-wagon-private/test/sample-project x-remove-mkdirs* 14s
❯ AWS_PROFILE=noob lein deploy testing
Created /Users/rayh/projects/s3-wagon-private/test/sample-project/target/test-project-0.0.1-SNAPSHOT.jar
Wrote /Users/rayh/projects/s3-wagon-private/test/sample-project/pom.xml
Retrieving s3-wagon-private/test-project/0.0.1-SNAPSHOT/maven-metadata.xml
    from s3p://wagon/snapshots/
Sending s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045515-2.jar
    to s3p://wagon/snapshots/
Sending s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045515-2.pom
    to s3p://wagon/snapshots/
Retrieving s3-wagon-private/test-project/maven-metadata.xml
    from s3p://wagon/snapshots/
Sending s3-wagon-private/test-project/0.0.1-SNAPSHOT/maven-metadata.xml
    to s3p://wagon/snapshots/
Sending s3-wagon-private/test-project/maven-metadata.xml
    to s3p://wagon/snapshots/

❯ AWS_PROFILE=noob aws s3 ls --recursive s3://wagon/snapshots/
2017-03-14 21:55:18        778 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/maven-metadata.xml
2017-03-14 21:55:18         32 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/maven-metadata.xml.md5
2017-03-14 21:55:18         40 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/maven-metadata.xml.sha1
2017-03-14 21:55:00       3241 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045459-1.jar
2017-03-14 21:55:01         32 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045459-1.jar.md5
2017-03-14 21:55:00         40 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045459-1.jar.sha1
2017-03-14 21:55:01       2204 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045459-1.pom
2017-03-14 21:55:01         32 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045459-1.pom.md5
2017-03-14 21:55:01         40 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045459-1.pom.sha1
2017-03-14 21:55:16       3241 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045515-2.jar
2017-03-14 21:55:17         32 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045515-2.jar.md5
2017-03-14 21:55:17         40 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045515-2.jar.sha1
2017-03-14 21:55:17       2204 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045515-2.pom
2017-03-14 21:55:17         32 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045515-2.pom.md5
2017-03-14 21:55:17         40 snapshots/s3-wagon-private/test-project/0.0.1-SNAPSHOT/test-project-0.0.1-20170315.045515-2.pom.sha1
2017-03-14 21:55:18        288 snapshots/s3-wagon-private/test-project/maven-metadata.xml
2017-03-14 21:55:18         32 snapshots/s3-wagon-private/test-project/maven-metadata.xml.md5
2017-03-14 21:55:18         40 snapshots/s3-wagon-private/test-project/maven-metadata.xml.sha1
```

</details>
