### PR TITLE
[deps] Bump the version of aws-sdk.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.28</version>
+                <version>1.11.98</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
We're having issues where the old version of aws-java-sdk is bring brought in and is incompatible. 