### PR TITLE
Upgrades to latest version of aws SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.28</version>
+                <version>1.11.184</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This allows using us-east-2 as a region for S3 buckets. Fixes https://github.com/s3-wagon-private/s3-wagon-private/issues/46 cc @sheelc 