### PR TITLE
Bump jackson.core and jackson.databind...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.5.5</version>
+            <version>2.6.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.5.5</version>
+            <version>2.6.7.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
To match versions pulled in by aws-java-sdk-s3.

Fixes #45. See also https://github.com/boot-clj/boot/pull/679.