### PR TITLE
Updates amazon dependency which no longer uses JAXB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.184</version>
+                <version>1.11.337</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
The new amazon libs don't have the problem present when using Java 10;
Caused by: java.lang.ClassNotFoundException:
javax.xml.bind.JAXBException