### PR TITLE
Update jackson-core/jackson-databind versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.6.7</version>
+            <version>2.9.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.7.1</version>
+            <version>2.9.7</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
We're currently running into the following error when using
s3-wagon-private in a project that uses the latest AWS SDK:

```
Exception in thread "main" Exception in thread "pool-3-thread-1" java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.JavaType.isReferenceType()Z
```

This commit upgrades the versions of `jackson-core` and `jackson-databind`
to the latest versions - which fixes this issue for us.

Let me know if you'd like me to bump the version number or anything like that.