### PR TITLE
Fix the dependency conflict issue #68

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,17 +44,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework.build</groupId>
-            <artifactId>aws-maven</artifactId>
-            <version>4.8.0.RELEASE</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.amazonaws</groupId>
-                    <artifactId>aws-java-sdk</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <exclusions>
@@ -65,6 +54,17 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.build</groupId>
+            <artifactId>aws-maven</artifactId>
+            <version>4.8.0.RELEASE</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.amazonaws</groupId>
+                    <artifactId>aws-java-sdk</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
I can provide a short description of issue #68:

In **s3-wagon-private v1.3.2**, duplicate classes with the same fully-qualified name **org.apache.commons.logging.LogFactory** are included in two different libraries, i.e., **org.slf4j:jcl-over-slf4j:1.7.5** and **commons-logging:commons-logging:1.1.3**. 

According to "first declaration wins" class loading strategy, only this class in **org.slf4j:jcl-over-slf4j:1.7.5** can be loaded, and that in **commons-logging:commons-logging:1.1.3** will be shadowed.

By further analyzing, your project expects to invoke method **<org.apache.commons.logging.LogFactory: org.apache.commons.logging.LogFactory getFactory()>** in **commons-logging:commons-logging:1.1.3**. As it has been shadowed, so that this method defined in **org.slf4j:jcl-over-slf4j:1.7.5** is actually forced to be referenced.

Although both of these two conflicting classes contain the referenced method (with the same signature), they have completely different implementations. This issue will not lead to runtime crashes, but it can introduce inconsistent semantic hehaviors by changing the control flows and data flows.




**Solution:**


There are two solutions can be adopted to solve this dependency conflict issue:

1.Reverse the declaration order of **org.slf4j:jcl-over-slf4j:1.7.5** and **commons-logging:commons-logging:1.1.3** in pom.xml.
Then, according to "first declaration wins" class loading strategy, class _**org.apache.commons.logging.LogFactory**_ in _**commons-logging:commons-logging:1.1.3**_ can be loaded (the version s3-wagon-private expects to reference by static analysis).

This fix will not affect other libraries or class, except the above duplicate class.

2.Specify **commons-logging:commons-logging:1.1.3** as a direct dependency in the dependency tree.


This patch adopts the first solution.