### PR TITLE
Updated aws-sdk to version 1.11.579.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.337</version>
+                <version>1.11.579</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This fixes the "Cannot create enum from eu-north-1 value!" error.