### PR TITLE
Breaking: Provide the AWS secret key using password instead of passphrase

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.0
+
+### Breaking changes
+
+* Version 2.0.0 is a breaking change **and is released under `s3-wagon-private/s3-wagon-private2`**. It entirely removes support for using `:passphrase` to pass the AWS Secret Key and instead uses `:password`. This has been a big source of confusion for people and caused several downstream problems. See [#31](https://github.com/s3-wagon-private/s3-wagon-private/issues/31) and [#47](https://github.com/s3-wagon-private/s3-wagon-private/issues/47) for more details.
+
+  You can continue to use the version 1 series without problem, and they will continue to receive bugfix updates in the `version1` branch.
+ 
+  If you wish to migrate to version 2, upgrade your dependency to `s3-wagon-private/s3-wagon-private2 "2.0.0"` and update your config from:
+
+    
+   ```clj
+   :repositories {"releases"  {:url           "s3p://my-maven/releases/"
+                               :username      :env/my_cool_aws_access_key_id
+                               :passphrase    :env/my_cool_aws_secret_access_key
+                               :sign-releases false}}
+   ```
+   
+   to:
+
+   ```clj
+   :repositories {"releases"  {:url           "s3p://my-maven/releases/"
+                               :username      :env/my_cool_aws_access_key_id
+                               :password      :env/my_cool_aws_secret_access_key
+                               :sign-releases false}}
+   ```
+
+
 ## [1.3.3]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the plugin and repositories listing to `project.clj`.
 **NB: You need to add these to your `project.clj`, not your personal `~/.lein/profiles.clj`. For more details on why, see Leiningen's doc on [repeatability](https://github.com/technomancy/leiningen/wiki/Repeatability#user-level-repositories)**:
 
 ```clj
-:plugins [[s3-wagon-private "1.3.1"]]
+:plugins [[s3-wagon-private/s3-wagon-private2 "2.0.0"]]
 ```
 
 To authenticate to the S3 bucket, you can either use any of the AWS SDK credential providers, store credentials in an encrypted file, or store your credentials in arbitrary environment variables.
@@ -48,13 +48,26 @@ Add the following to `project.clj`:
 
 And in `~/.lein/credentials.clj.gpg`:
 
+**Versions 2.0.0 and above (s3-wagon-private2)**
+
+```
+ {"s3p://mybucket/releases" {:username "AKIA2489AE28488" ;; AWS Access Key
+                             :password "98b0b104ca1211e19a6c" ;; AWS Secret Key
+                             }}
+```
+
+
+**Versions below 2.0.0 (s3-wagon-private)**
+
+Note that this uses `:passphrase` instead of `:password`.
+
 ```
  {"s3p://mybucket/releases" {:username "AKIA2489AE28488" ;; AWS Access Key
                              :passphrase "98b0b104ca1211e19a6c" ;; AWS Secret Key
                              }}
 ```
 
-The map key here can be either a string for an exact match or a regex
+The map key (`"s3p://mybucket/releases"` in the example) can be either a string for an exact match or a regex
 checked against the repository URL if you have the same credentials
 for multiple repositories.
 
@@ -62,8 +75,24 @@ See `lein help deploying` for additional details on storing credentials.
 
 #### Store credentials under arbitrary environment variables
 
+**Versions 2.0.0 and above (s3-wagon-private2)**
+
 ```clj
-:repositories {"releases"  {:url "s3p://my-maven/releases/"
+:repositories {"releases"  {:url           "s3p://my-maven/releases/"
+                            :username      :env/my_cool_aws_access_key_id
+                            :password      :env/my_cool_aws_secret_access_key
+                            :sign-releases false}
+               "snapshots" {:url           "s3p://my-maven/snapshots/"
+                            :username      :env/my_cool_aws_access_key_id
+                            :password      :env/my_cool_aws_secret_access_key}}
+```
+
+**Versions below 2.0.0 (s3-wagon-private)**
+
+Note that this uses `:passphrase` instead of `:password`.
+
+```clj
+:repositories {"releases"  {:url           "s3p://my-maven/releases/"
                             :username      :env/my_cool_aws_access_key_id
                             :passphrase    :env/my_cool_aws_secret_access_key
                             :sign-releases false}
@@ -127,21 +156,38 @@ See `lein help deploying` for additional details on storing credentials.
 
 This xml is only necessary if not using one of the AWS SDK [chained provider class][chained-provider-class] methods of authentication.
 
+**Versions 2.0.0 and above (s3-wagon-private2)**
+
 ```xml
-
-
 <settings>
     <servers>
         <server>
             <!-- you can actually put the key and secret in here, I like to get them from the env -->
             <id>someId</id>
             <username>${env.AWS_ACCESS_KEY}</username>
-            <privateKey>${user.home}/.ssh/id_rsa</privateKey>
+            <password>${env.AWS_SECRET_KEY}</privateKey>
+        </server>
+    </servers>
+</settings>
+```
+
+
+**Versions below 2.0.0 (s3-wagon-private)**
+
+Note that this uses `:passphrase` instead of `:password` and includes an arbitrary `privateKey` string to trigger the correct behaviour.
+
+```xml
+<settings>
+    <servers>
+        <server>
+            <!-- you can actually put the key and secret in here, I like to get them from the env -->
+            <id>someId</id>
+            <username>${env.AWS_ACCESS_KEY}</username>
+            <privateKey>none</privateKey>
             <passphrase>${env.AWS_SECRET_KEY}</passphrase>
         </server>
     </servers>
 </settings>
-
 ```
 
 #### AWS Policy
@@ -198,7 +244,7 @@ mvn deploy
 
 ## License
 
-Copyright © 2011-2013 Phil Hagelberg, Scott Clasen, Allen Rohner
+Copyright © 2011-2019 Phil Hagelberg, Scott Clasen, Allen Rohner, Daniel Compton
 
 Based on [aws-maven](http://git.springsource.org/spring-build/aws-maven)
 from the Spring project.

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>s3-wagon-private</groupId>
-    <artifactId>s3-wagon-private</artifactId>
-    <version>1.3.3-SNAPSHOT</version>
+    <artifactId>s3-wagon-private2</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
     <description>Deploy and consume artifacts in private S3 repositories.</description>
     <url>https://github.com/technomancy/s3-wagon-private</url>
     <scm>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.springframework.build</groupId>
             <artifactId>aws-maven</artifactId>
-            <version>4.8.0.RELEASE</version>
+            <version>5.0.0.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>

--- a/src/main/java/org/springframework/build/aws/maven/PrivateS3Wagon.java
+++ b/src/main/java/org/springframework/build/aws/maven/PrivateS3Wagon.java
@@ -58,7 +58,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
  * <code>s3://static.springframework.org</code> would put files into the <code>static.springframework.org</code> bucket
  * on the S3 service.
  * <p/>
- * This implementation uses the <code>username</code> and <code>passphrase</code> portions of the server authentication
+ * This implementation uses the <code>username</code> and <code>password</code> portions of the server authentication
  * metadata for credentials.
  */
 public final class PrivateS3Wagon extends AbstractWagon {
@@ -102,10 +102,7 @@ public final class PrivateS3Wagon extends AbstractWagon {
             if (authenticationInfo == null) {
                 defaultCredProvider = true;
             } else if (authenticationInfo.getUserName() == null &&
-                       authenticationInfo.getPassword() == null &&
-                       authenticationInfo.getPassphrase() == null &&
-                       (authenticationInfo.getPrivateKey() == null ||
-                        authenticationInfo.getPrivateKey().equals(""))) {
+                       authenticationInfo.getPassword() == null) {
                 defaultCredProvider = true;
             }
 
@@ -143,7 +140,7 @@ public final class PrivateS3Wagon extends AbstractWagon {
     private com.amazonaws.regions.Region parseRegion(String region) {
         return com.amazonaws.regions.Region.getRegion(Regions.fromName(region));
     }
-    
+
     @Override
     protected void disconnectFromRepository() {
         this.amazonS3 = null;


### PR DESCRIPTION
This also updates to version 5.0.0 of the aws-maven project and changes
the artifact ID to s3-wagon-private2.

I still need to test this properly, but opening it up for discussion
about the changes, particularly using a new artifact ID.

Fixes #31 and #47.