### PR TITLE
Adding a cloudformation template

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ This xml is only necessary if not using one of the AWS SDK [chained provider cla
 
 ```
 
-#### AWS Policy
+#### AWS Setup
 
 Here's a sample AWS policy that would allow both read and write access to
 the bucket `mybucket`:
@@ -170,7 +170,6 @@ the bucket `mybucket`:
             "Action": [
                 "s3:GetObject",
                 "s3:GetObjectVersion",
-                "s3:ListBucket",
                 "s3:PutObject"
             ],
             "Resource": [
@@ -179,6 +178,16 @@ the bucket `mybucket`:
         }
     ]
 }
+```
+You may also use the `cloudformation-template.yml` to set your S3 bucket up:
+
+```
+export UserArn=$(aws iam get-user --profile $AWS_PROFILE | jq -r '.User.Arn')
+aws cloudformation deploy \
+  --stack-name s3-maven-repo \
+  --template-file cloudformation-template.yml \
+  --parameter-overrides BucketName="s3-maven-repo" UserArn="${UserArn}"
+
 ```
 
 ## Troubleshooting

--- a/cloudformation-template.yml
+++ b/cloudformation-template.yml
@@ -1,0 +1,59 @@
+Description: Creates a bucket to go with the s3-wagon-private
+Parameters:
+  UserArn:
+    Description: the ARN of your AWS user entity
+    Type: String
+  BucketName:
+    Description: The name of the bucket for your maven repo
+    Type: String
+    Default: MavenRepo
+    MinLength: 1
+    MaxLength: 64
+    AllowedPattern: ^[a-zA-Z0-9_-]*$
+
+Resources:
+  MavenRepoBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketName
+    DeletionPolicy: Retain
+
+  MavenRepoBucketPolicy:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref BucketName
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListBucket
+              - s3:GetBucketLocation
+            Resource:
+              - !Sub "arn:aws:s3:::${BucketName}"
+            Principal:
+              AWS:
+                - !Ref UserArn
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+              - s3:GetObjectVersion
+              - s3:PutObject
+            Resource:
+              - !Sub "arn:aws:s3:::${BucketName}/*"
+            Principal:
+              AWS:
+                - !Ref UserArn
+
+Outputs:
+  MavenRepoBucketName:
+    Value: !Ref MavenRepoBucket
+    Description: The name of your maven repo bucket
+    Export:
+      Name: "MavenRepoBucketName"
+
+  MavenRepoBucketDomainName:
+    Value: !GetAtt MavenRepoBucket.DomainName
+    Description: The domain name of your maven repo bucket
+    Export:
+      Name: "MavenRepoBucketDomainName"
+


### PR DESCRIPTION
Hi! my colleague wanted me to set up a private maven repo, so I found your project.

I've set up a cloudformation template that simplified the S3 bucket setup - so I thought I'd share that with you.
Also, while testing it out, I noted that the 's3:ListBucket' action in the sample AWS policy in your README.md may not apply to the bucket's content, but only to the bucket itself - so it had to be removed.

So, yeah, thanks for your work!