### PR TITLE
Bump jackson + aws-sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.9</version>
+            <version>2.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.1</version>
+            <version>2.12.4</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.713</version>
+                <version>1.12.49</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Hi, not sure if there is some reason to not bump jackson, is just that versions below 2.10 doesn't work with [lein-clojure-lsp](https://github.com/clojure-lsp/lein-clojure-lsp), I can use :exclusions, but I thought it'd be better try to bump it